### PR TITLE
Fix fatal bug on not recognizing character index

### DIFF
--- a/xpholder/commands/everyone/xp.js
+++ b/xpholder/commands/everyone/xp.js
@@ -112,7 +112,7 @@ module.exports = {
         // pageIndex depends on the character_index, if not found, default to 0
         let pageIndex = 0;
         let index = 0;
-        for (let character of characterEmbeds) {
+        for (let character of playerCharacters) {
             if (character["character_index"] == embedCharacterNumber) {
                 pageIndex = index;
             }


### PR DESCRIPTION
Fix previous fatal bug on character index not recognized. Previously I didn't notice the character set was always the first character.
Now it's better tested.

Tests done:
* Switching character
  * The same character
  * From 1 to 2
  * From 2 to 1
* Approving and Retiring new character
  * Approve Slot 1
  * Approve Slot 2
  * Approve Slot 3
  * Retire Slot 1
  * Activate Slot 2
  * Retire Slot 2
  * Opens /xp, still runs
  * Activate Slot 3
  * Approve Slot 1
  * Activate Slot 1
* Award XP