### PR TITLE
Bugfixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ CMD ["node", "main.js"]
 
 FROM node:20-alpine AS dashboard
 WORKDIR /app
-COPY dashboard/package*.json ./
-RUN npm install
-COPY dashboard/ .
-RUN npx tailwindcss -i ./public/css/input.css -o ./public/css/style.css --minify
-CMD ["node", "server.js"]
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN cd dashboard && npx tailwindcss -i ./public/css/input.css -o ./public/css/style.css --minify
+CMD ["node", "dashboard/server.js"]

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -72,13 +72,21 @@ app.use((req, res, next) => {
       const bracketMatch = name.match(/^\[([^\]]+)\]/);
       if (bracketMatch) return bracketMatch[1].trim();
     }
-    const segments = name.split(/[|¦│[\]{}《》]|[\u{1F000}-\u{1FFFF}\u{2600}-\u{27BF}\u{2700}-\u{27BF}\u{FE00}-\u{FEFF}\u{1F900}-\u{1F9FF}\u{2300}-\u{23FF}☃★♦♠♣♥✦✧❤♤]/u);
+    const segments = name.split(/[|¦│[\]{}《》]|[\u{1F000}-\u{1FFFF}\u{2600}-\u{27BF}\u{2700}-\u{27BF}\u{FE00}-\u{FEFF}\u{1F900}-\u{1F9FF}\u{2300}-\u{23FF}\u{2B00}-\u{2BFF}☃★♦♠♣♥✦✧❤♤]/u);
     let raw = segments[0].trim();
     if (!raw) raw = segments.find((s) => s.trim()) || name;
-    return raw
+    raw = raw
       .replace(/\s*\(.*$/, "")
       .replace(/[⁰¹²³⁴⁵⁶⁷⁸⁹ᴬᴮᴰᴱᴳᴴᴵᴶᴷᴸᴹᴺᴼᴾᴿˢᵀᵁⱽᵂ]+.*$/, "")
-      .trim() || name;
+      .replace(/-[^-\s]+$/, "")
+      .trim();
+    // If what remains still has spaces AND the tail contains digits or a
+    // timezone abbrev, treat the rest as roster/timezone info and keep only
+    // the first word. Leaves real multi-word names (e.g. "Sir Ellic") intact.
+    if (raw.includes(" ") && /\d|\b(UTC|EST|PST|CST|MST|GMT|CET|CEST|BST|AEST|AEDT|JST|IST)\b/i.test(raw)) {
+      raw = raw.split(/\s+/)[0];
+    }
+    return raw || name;
   };
   next();
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ./dashboard:/app
+      - .:/app
       - /app/node_modules
     depends_on:
       db:

--- a/main.js
+++ b/main.js
@@ -205,6 +205,15 @@ client.on("interactionCreate", async (interaction) => {
         console.log(error);
       }
       console.log(error);
+      try {
+        if (interaction.deferred || interaction.replied) {
+          await interaction.editReply(
+            "Something went wrong running that command. Please check your inputs and try again."
+          );
+        }
+      } catch (replyError) {
+        console.log(replyError);
+      }
     }
   }
 

--- a/xpholder/commands/mod/eventAddDm.js
+++ b/xpholder/commands/mod/eventAddDm.js
@@ -38,8 +38,18 @@ module.exports = {
     }
 
     const eventId = parseInt(interaction.options.getString("event"));
+    if (isNaN(eventId)) {
+      await interaction.editReply("Please pick an event from the autocomplete list.");
+      return;
+    }
     const dm = interaction.options.getUser("dm");
-    const dmMember = await interaction.guild.members.fetch(dm.id);
+    let dmMember;
+    try {
+      dmMember = await interaction.guild.members.fetch(dm.id);
+    } catch {
+      await interaction.editReply("That user is no longer in the server.");
+      return;
+    }
 
     const event = await guildService.getEvent(eventId);
     if (!event) {

--- a/xpholder/commands/mod/eventAddPc.js
+++ b/xpholder/commands/mod/eventAddPc.js
@@ -48,7 +48,17 @@ module.exports = {
     }
 
     const eventId = parseInt(interaction.options.getString("event"));
+    if (isNaN(eventId)) {
+      await interaction.editReply("Please pick an event from the autocomplete list.");
+      return;
+    }
     const player = interaction.options.getUser("player");
+    try {
+      await interaction.guild.members.fetch(player.id);
+    } catch {
+      await interaction.editReply("That player is no longer in the server.");
+      return;
+    }
     const characterIndex = interaction.options.getInteger("character");
     const characterId = `${player.id}-${characterIndex}`;
 

--- a/xpholder/commands/mod/eventDelete.js
+++ b/xpholder/commands/mod/eventDelete.js
@@ -32,6 +32,10 @@ module.exports = {
     }
 
     const eventId = parseInt(interaction.options.getString("event"));
+    if (isNaN(eventId)) {
+      await interaction.editReply("Please pick an event from the autocomplete list.");
+      return;
+    }
 
     const event = await guildService.getEvent(eventId);
     if (!event) {

--- a/xpholder/commands/mod/eventEdit.js
+++ b/xpholder/commands/mod/eventEdit.js
@@ -1,0 +1,162 @@
+const { SlashCommandBuilder } = require("@discordjs/builders");
+const { EmbedBuilder } = require("discord.js");
+const { XPHOLDER_COLOUR } = require("../../config.json");
+const { isValidYmd } = require("../../utils/validation");
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName("event_edit")
+    .setDescription("Edit The Details Of An Event! [ MOD ]")
+    .addStringOption((option) =>
+      option
+        .setName("event")
+        .setDescription("The Event To Edit")
+        .setAutocomplete(true)
+        .setRequired(true)
+    )
+    .addStringOption((option) =>
+      option
+        .setName("name")
+        .setDescription("New Name For The Event")
+        .setRequired(false)
+    )
+    .addStringOption((option) =>
+      option
+        .setName("event_type")
+        .setDescription("New Event Type")
+        .addChoices(
+          { name: "Mission", value: "Mission" },
+          { name: "Adventure", value: "Adventure" },
+          { name: "Skirmish", value: "Skirmish" },
+          { name: "Arena", value: "Arena" },
+          { name: "Discourse", value: "Discourse" },
+          { name: "Arc Quest", value: "Arc Quest" }
+        )
+        .setRequired(false)
+    )
+    .addStringOption((option) =>
+      option
+        .setName("tier")
+        .setDescription("New Tier / Level Bracket")
+        .addChoices(
+          { name: "3-4", value: "3-4" },
+          { name: "5-7", value: "5-7" },
+          { name: "8-10", value: "8-10" },
+          { name: "11-13", value: "11-13" },
+          { name: "14-16", value: "14-16" },
+          { name: "17-20", value: "17-20" },
+          { name: "Open", value: "Open" }
+        )
+        .setRequired(false)
+    )
+    .addStringOption((option) =>
+      option
+        .setName("start_date")
+        .setDescription("New Start Date (YYYY-MM-DD)")
+        .setRequired(false)
+    )
+    .addUserOption((option) =>
+      option
+        .setName("primary_dm")
+        .setDescription("New Primary DM")
+        .setRequired(false)
+    )
+    .addBooleanOption((option) =>
+      option
+        .setName("public")
+        .setDescription("Show This Command To Everyone?")
+        .setRequired(false)
+    ),
+  async execute(guildService, interaction) {
+    if (
+      !guildService.isMod(interaction.member._roles) &&
+      interaction.user.id != interaction.guild.ownerId &&
+      !guildService.isDev(interaction.member._roles)
+    ) {
+      await interaction.editReply(
+        "Sorry, you do not have the right role to use this command."
+      );
+      return;
+    }
+
+    const eventId = parseInt(interaction.options.getString("event"));
+    if (isNaN(eventId)) {
+      await interaction.editReply("Please pick an event from the autocomplete list.");
+      return;
+    }
+
+    const event = await guildService.getEvent(eventId);
+    if (!event) {
+      await interaction.editReply("Sorry, that event does not exist.");
+      return;
+    }
+
+    const name = interaction.options.getString("name");
+    const eventType = interaction.options.getString("event_type");
+    const tier = interaction.options.getString("tier");
+    const startDateStr = interaction.options.getString("start_date");
+    const primaryDmUser = interaction.options.getUser("primary_dm");
+
+    if (startDateStr && !isValidYmd(startDateStr)) {
+      await interaction.editReply(
+        "Invalid `start_date`. Use `YYYY-MM-DD` (e.g. `2026-04-15`)."
+      );
+      return;
+    }
+
+    if (!name && !eventType && !tier && !startDateStr && !primaryDmUser) {
+      await interaction.editReply(
+        "Nothing to update. Provide at least one field to change."
+      );
+      return;
+    }
+
+    const fields = {};
+    if (name) fields.name = name;
+    if (eventType) fields.event_type = eventType;
+    if (tier) fields.tier = tier;
+    if (startDateStr) fields.start_date = startDateStr;
+
+    await guildService.updateEvent(eventId, fields);
+
+    let newPrimaryDmLabel = null;
+    if (primaryDmUser) {
+      let dmMember;
+      try {
+        dmMember = await interaction.guild.members.fetch(primaryDmUser.id);
+      } catch {
+        await interaction.editReply("That user is no longer in the server.");
+        return;
+      }
+      await guildService.setPrimaryDm(eventId, primaryDmUser.id, dmMember.displayName);
+      newPrimaryDmLabel = `${primaryDmUser}`;
+    }
+
+    const updated = await guildService.getEvent(eventId);
+    const startDate = updated.start_date.toISOString().split("T")[0];
+
+    const embed = new EmbedBuilder()
+      .setTitle("Event Updated")
+      .setColor(XPHOLDER_COLOUR)
+      .setFields(
+        { inline: true, name: "Name", value: updated.name },
+        { inline: true, name: "Type", value: updated.event_type },
+        { inline: true, name: "Tier", value: updated.tier },
+        { inline: true, name: "Start Date", value: startDate },
+        { inline: true, name: "Event ID", value: `${eventId}` },
+        ...(newPrimaryDmLabel
+          ? [{ inline: true, name: "Primary DM", value: newPrimaryDmLabel }]
+          : [])
+      )
+      .setTimestamp();
+
+    await interaction.editReply({ embeds: [embed] });
+  },
+  async autocomplete(guildService, interaction) {
+    const focusedValue = interaction.options.getFocused();
+    const events = await guildService.searchEvents(focusedValue);
+    await interaction.respond(
+      events.map((e) => ({ name: e.name, value: `${e.event_id}` }))
+    );
+  },
+};

--- a/xpholder/commands/mod/eventEnd.js
+++ b/xpholder/commands/mod/eventEnd.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder } = require("@discordjs/builders");
 const { EmbedBuilder } = require("discord.js");
 const { XPHOLDER_APPROVE_COLOUR } = require("../../config.json");
+const { isValidYmd } = require("../../utils/validation");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -23,12 +24,16 @@ module.exports = {
       option
         .setName("xp_reward")
         .setDescription("XP reward for completing this event")
+        .setMinValue(0)
+        .setMaxValue(1000000)
         .setRequired(false)
     )
     .addIntegerOption((option) =>
       option
         .setName("gp_reward")
         .setDescription("GP reward for completing this event")
+        .setMinValue(0)
+        .setMaxValue(1000000)
         .setRequired(false)
     )
     .addBooleanOption((option) =>
@@ -50,7 +55,17 @@ module.exports = {
     }
 
     const eventId = parseInt(interaction.options.getString("event"));
+    if (isNaN(eventId)) {
+      await interaction.editReply("Please pick an event from the autocomplete list.");
+      return;
+    }
     const endDateStr = interaction.options.getString("end_date");
+    if (endDateStr && !isValidYmd(endDateStr)) {
+      await interaction.editReply(
+        "Invalid `end_date`. Use `YYYY-MM-DD` (e.g. `2026-04-15`)."
+      );
+      return;
+    }
     const endDate = endDateStr || new Date().toISOString().split("T")[0];
     const xpReward = interaction.options.getInteger("xp_reward");
     const gpReward = interaction.options.getInteger("gp_reward");

--- a/xpholder/commands/mod/eventInfo.js
+++ b/xpholder/commands/mod/eventInfo.js
@@ -32,6 +32,10 @@ module.exports = {
     }
 
     const eventId = parseInt(interaction.options.getString("event"));
+    if (isNaN(eventId)) {
+      await interaction.editReply("Please pick an event from the autocomplete list.");
+      return;
+    }
 
     const event = await guildService.getEvent(eventId);
     if (!event) {

--- a/xpholder/commands/mod/eventRemovePc.js
+++ b/xpholder/commands/mod/eventRemovePc.js
@@ -47,6 +47,10 @@ module.exports = {
     }
 
     const eventId = parseInt(interaction.options.getString("event"));
+    if (isNaN(eventId)) {
+      await interaction.editReply("Please pick an event from the autocomplete list.");
+      return;
+    }
     const player = interaction.options.getUser("player");
     const characterIndex = interaction.options.getInteger("character");
     const characterId = `${player.id}-${characterIndex}`;

--- a/xpholder/commands/mod/eventStart.js
+++ b/xpholder/commands/mod/eventStart.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder } = require("@discordjs/builders");
 const { EmbedBuilder } = require("discord.js");
 const { XPHOLDER_COLOUR } = require("../../config.json");
+const { isValidYmd } = require("../../utils/validation");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -77,6 +78,12 @@ module.exports = {
     const dmUser = interaction.options.getUser("primary_dm") || interaction.user;
     const dmMember = await interaction.guild.members.fetch(dmUser.id);
     const startDateStr = interaction.options.getString("start_date");
+    if (startDateStr && !isValidYmd(startDateStr)) {
+      await interaction.editReply(
+        "Invalid `start_date`. Use `YYYY-MM-DD` (e.g. `2026-04-15`)."
+      );
+      return;
+    }
     const startDate = startDateStr || new Date().toISOString().split("T")[0];
 
     const eventId = await guildService.createEvent(

--- a/xpholder/services/guild.js
+++ b/xpholder/services/guild.js
@@ -610,6 +610,38 @@ class guildService {
     );
   }
 
+  async updateEvent(eventId, fields) {
+    const allowed = ["name", "event_type", "tier", "start_date"];
+    const setClauses = [];
+    const values = [];
+    let i = 1;
+    for (const col of allowed) {
+      if (fields[col] !== undefined) {
+        setClauses.push(`${col} = $${i++}`);
+        values.push(fields[col]);
+      }
+    }
+    if (setClauses.length === 0) return;
+    values.push(eventId);
+    await this.db.query(
+      `UPDATE ${this.schema}.events SET ${setClauses.join(", ")} WHERE event_id = $${i};`,
+      values
+    );
+  }
+
+  async setPrimaryDm(eventId, userId, username) {
+    await this.db.query(
+      `UPDATE ${this.schema}.event_dms SET is_primary = FALSE WHERE event_id = $1;`,
+      [eventId]
+    );
+    await this.db.query(
+      `INSERT INTO ${this.schema}.event_dms (event_id, user_id, username, is_primary)
+       VALUES ($1, $2, $3, TRUE)
+       ON CONFLICT (event_id, user_id) DO UPDATE SET is_primary = TRUE, username = EXCLUDED.username;`,
+      [eventId, userId, username]
+    );
+  }
+
   async addEventParticipant(eventId, characterId, playerId, characterName, startingLevel, startingXp) {
     await this.db.query(
       `INSERT INTO ${this.schema}.event_participants (event_id, character_id, player_id, character_name, starting_level, starting_xp) VALUES ($1, $2, $3, $4, $5, $6);`,

--- a/xpholder/services/guild.js
+++ b/xpholder/services/guild.js
@@ -27,6 +27,7 @@ class guildService {
     if (!(await this.isRegistered())) {
       return;
     }
+    this.registered = true;
     this.config = await this.loadInit("config", "name", "value");
     this.levels = await this.loadInit("levels", "level", "xp_to_next");
     this.roles = await this.loadInit("roles", "role_id", "xp_bonus");

--- a/xpholder/utils/validation.js
+++ b/xpholder/utils/validation.js
@@ -1,0 +1,7 @@
+function isValidYmd(str) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(str)) return false;
+  const d = new Date(`${str}T00:00:00Z`);
+  return !isNaN(d.getTime()) && d.toISOString().startsWith(str);
+}
+
+module.exports = { isValidYmd };


### PR DESCRIPTION
  ## New command              
  - `/event_edit` — lets mods fix event details after creation (name, type, tier, start date, primary DM). Uses 
  dynamic partial UPDATE via a new updateEvent service method and a new setPrimaryDm helper that flips        
  is_primary atomically.                                                                              
                                                                                                              
  ## Input validation on event commands                        
  - New `xpholder/utils/validation.js` with isValidYmd() — validates YYYY-MM-DD format and that the date is     
  real.                                                                                                       
  - `/event_start` and `/event_end` now reject malformed dates with a clear error instead of hanging on the DB    
  throw.                                                                                                      
  - eventId NaN guard added to `/event_end`, `/event_delete`, `/event_info`, `/event_add_dm`, `/event_add_pc`,          
  `/event_remove_pc` — catches users who type free text instead of picking from autocomplete.         
  - `/event_end` reward fields bounded to 0–1,000,000 to prevent negatives and Postgres INTEGER overflow.       
  - `/event_add_dm` and `/event_add_pc wrap` guild.members.fetch() in try/catch so targeting a user who left the
  server gives a friendly reply instead of throwing.                                                          
                                                                                                              
  ## Global safety net                                                                                           
  - `main.js` — when any command throws, we now editReply with a user-visible error message. Previously the     
  error was logged but the interaction was left in "thinking…" forever until the 15-minute token expired.     
   
 ## Docker / deployment fix                                                                                     
  - `Dockerfile` — dashboard stage was building from the now-deleted dashboard/package.json. Updated to install
  from root and run Tailwind from the dashboard subdir so utility-class detection works.                      
  - `docker-compose.yml` — dashboard service volume mount switched from ./dashboard:/app to .:/app so the merged
   dependency tree is visible. 