### PR TITLE
Event id fallback against submission cache pollution

### DIFF
--- a/xpholder/commands/mod/eventAddDm.js
+++ b/xpholder/commands/mod/eventAddDm.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder } = require("@discordjs/builders");
 const { EmbedBuilder } = require("discord.js");
 const { XPHOLDER_COLOUR } = require("../../config.json");
+const { resolveEventOption } = require("../../utils/resolveEventOption");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -37,11 +38,8 @@ module.exports = {
       return;
     }
 
-    const eventId = parseInt(interaction.options.getString("event"));
-    if (isNaN(eventId)) {
-      await interaction.editReply("Please pick an event from the autocomplete list.");
-      return;
-    }
+    const eventId = await resolveEventOption(interaction, guildService, "active");
+    if (eventId == null) return;
     const dm = interaction.options.getUser("dm");
     let dmMember;
     try {

--- a/xpholder/commands/mod/eventAddPc.js
+++ b/xpholder/commands/mod/eventAddPc.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder } = require("@discordjs/builders");
 const { EmbedBuilder } = require("discord.js");
 const { XPHOLDER_COLOUR } = require("../../config.json");
 const { getLevelInfo } = require("../../utils");
+const { resolveEventOption } = require("../../utils/resolveEventOption");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -47,11 +48,8 @@ module.exports = {
       return;
     }
 
-    const eventId = parseInt(interaction.options.getString("event"));
-    if (isNaN(eventId)) {
-      await interaction.editReply("Please pick an event from the autocomplete list.");
-      return;
-    }
+    const eventId = await resolveEventOption(interaction, guildService, "active");
+    if (eventId == null) return;
     const player = interaction.options.getUser("player");
     try {
       await interaction.guild.members.fetch(player.id);

--- a/xpholder/commands/mod/eventDelete.js
+++ b/xpholder/commands/mod/eventDelete.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder } = require("@discordjs/builders");
 const { EmbedBuilder } = require("discord.js");
 const { XPHOLDER_RETIRE_COLOUR } = require("../../config.json");
+const { resolveEventOption } = require("../../utils/resolveEventOption");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -31,11 +32,8 @@ module.exports = {
       return;
     }
 
-    const eventId = parseInt(interaction.options.getString("event"));
-    if (isNaN(eventId)) {
-      await interaction.editReply("Please pick an event from the autocomplete list.");
-      return;
-    }
+    const eventId = await resolveEventOption(interaction, guildService, "active");
+    if (eventId == null) return;
 
     const event = await guildService.getEvent(eventId);
     if (!event) {

--- a/xpholder/commands/mod/eventEdit.js
+++ b/xpholder/commands/mod/eventEdit.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder } = require("@discordjs/builders");
 const { EmbedBuilder } = require("discord.js");
 const { XPHOLDER_COLOUR } = require("../../config.json");
 const { isValidYmd } = require("../../utils/validation");
+const { resolveEventOption } = require("../../utils/resolveEventOption");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -101,11 +102,8 @@ module.exports = {
       return;
     }
 
-    const eventId = parseInt(interaction.options.getString("event"));
-    if (isNaN(eventId)) {
-      await interaction.editReply("Please pick an event from the autocomplete list.");
-      return;
-    }
+    const eventId = await resolveEventOption(interaction, guildService, "active");
+    if (eventId == null) return;
 
     const event = await guildService.getEvent(eventId);
     if (!event) {

--- a/xpholder/commands/mod/eventEnd.js
+++ b/xpholder/commands/mod/eventEnd.js
@@ -3,6 +3,7 @@ const { EmbedBuilder } = require("discord.js");
 const { XPHOLDER_APPROVE_COLOUR } = require("../../config.json");
 const { isValidYmd } = require("../../utils/validation");
 const { playerName } = require("../../utils/playerName");
+const { resolveEventOption } = require("../../utils/resolveEventOption");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -55,11 +56,8 @@ module.exports = {
       return;
     }
 
-    const eventId = parseInt(interaction.options.getString("event"));
-    if (isNaN(eventId)) {
-      await interaction.editReply("Please pick an event from the autocomplete list.");
-      return;
-    }
+    const eventId = await resolveEventOption(interaction, guildService, "active");
+    if (eventId == null) return;
     const endDateStr = interaction.options.getString("end_date");
     if (endDateStr && !isValidYmd(endDateStr)) {
       await interaction.editReply(

--- a/xpholder/commands/mod/eventInfo.js
+++ b/xpholder/commands/mod/eventInfo.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder } = require("@discordjs/builders");
 const { EmbedBuilder } = require("discord.js");
 const { XPHOLDER_COLOUR } = require("../../config.json");
 const { playerName } = require("../../utils/playerName");
+const { resolveEventOption } = require("../../utils/resolveEventOption");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -32,11 +33,8 @@ module.exports = {
       return;
     }
 
-    const eventId = parseInt(interaction.options.getString("event"));
-    if (isNaN(eventId)) {
-      await interaction.editReply("Please pick an event from the autocomplete list.");
-      return;
-    }
+    const eventId = await resolveEventOption(interaction, guildService, "active");
+    if (eventId == null) return;
 
     const event = await guildService.getEvent(eventId);
     if (!event) {

--- a/xpholder/commands/mod/eventRemoveDm.js
+++ b/xpholder/commands/mod/eventRemoveDm.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder } = require("@discordjs/builders");
 const { EmbedBuilder } = require("discord.js");
 const { XPHOLDER_RETIRE_COLOUR } = require("../../config.json");
 const { playerName } = require("../../utils/playerName");
+const { resolveEventOption } = require("../../utils/resolveEventOption");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -39,11 +40,8 @@ module.exports = {
       return;
     }
 
-    const eventId = parseInt(interaction.options.getString("event"));
-    if (isNaN(eventId)) {
-      await interaction.editReply("Please pick an event from the autocomplete list.");
-      return;
-    }
+    const eventId = await resolveEventOption(interaction, guildService, "active");
+    if (eventId == null) return;
     const dmUserId = interaction.options.getString("dm");
 
     const event = await guildService.getEvent(eventId);

--- a/xpholder/commands/mod/eventRemovePc.js
+++ b/xpholder/commands/mod/eventRemovePc.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder } = require("@discordjs/builders");
 const { EmbedBuilder } = require("discord.js");
 const { XPHOLDER_RETIRE_COLOUR } = require("../../config.json");
+const { resolveEventOption } = require("../../utils/resolveEventOption");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -38,11 +39,8 @@ module.exports = {
       return;
     }
 
-    const eventId = parseInt(interaction.options.getString("event"));
-    if (isNaN(eventId)) {
-      await interaction.editReply("Please pick an event from the autocomplete list.");
-      return;
-    }
+    const eventId = await resolveEventOption(interaction, guildService, "active");
+    if (eventId == null) return;
     const characterId = interaction.options.getString("character");
 
     const event = await guildService.getEvent(eventId);

--- a/xpholder/services/guild.integration.test.js
+++ b/xpholder/services/guild.integration.test.js
@@ -448,6 +448,31 @@ describe("events", () => {
     expect(bsHits.map((e) => e.name)).toEqual(["abc\\def"]);
   });
 
+  it("searchEventsExact returns case-insensitive exact-name matches scoped to status", async () => {
+    const { gService } = ctx;
+
+    // create three events: two named "Arena" (one active, one completed), and "arena 2" (a near-match)
+    const arenaActiveId = await gService.createEvent("Arena", "Mission", "5-7", "2026-01-01", "111", "dm-one");
+    const arenaCompletedId = await gService.createEvent("Arena", "Mission", "5-7", "2026-01-02", "222", "dm-two");
+    await gService.endEvent(arenaCompletedId, "2026-01-03");
+    await gService.createEvent("arena 2", "Mission", "5-7", "2026-01-04", "333", "dm-three");
+
+    const activeMatches = await gService.searchEventsExact("arena", "active");
+    expect(activeMatches.map((r) => r.event_id)).toEqual([arenaActiveId]);
+
+    const completedMatches = await gService.searchEventsExact("ARENA", "completed");
+    expect(completedMatches.map((r) => r.event_id)).toEqual([arenaCompletedId]);
+
+    // duplicate names within the same status should all return
+    const dup1 = await gService.createEvent("Arena", "Mission", "5-7", "2026-01-05", "444", "dm-four");
+    const allActive = await gService.searchEventsExact("arena", "active");
+    expect(allActive.map((r) => r.event_id).sort()).toEqual([arenaActiveId, dup1].sort());
+
+    // missing search returns empty
+    const none = await gService.searchEventsExact("Nope", "active");
+    expect(none).toEqual([]);
+  });
+
   it("updateEvent applies whitelisted columns and silently ignores unknown ones", async () => {
     const { gService } = ctx;
     const id = await makeEvent({ name: "Original" });

--- a/xpholder/services/guild.js
+++ b/xpholder/services/guild.js
@@ -597,6 +597,14 @@ class guildService {
     return res.rows;
   }
 
+  async searchEventsExact(name, status) {
+    const res = await this.db.query(
+      `SELECT * FROM ${this.schema}.events WHERE LOWER(name) = LOWER($1) AND status = $2 ORDER BY event_id DESC;`,
+      [name, status]
+    );
+    return res.rows;
+  }
+
   async endEvent(eventId, endDate, xpReward = null, gpReward = null) {
     await this.db.query(
       `UPDATE ${this.schema}.events SET status = 'completed', end_date = $1, xp_reward = $2, gp_reward = $3 WHERE event_id = $4;`,

--- a/xpholder/utils/logging.js
+++ b/xpholder/utils/logging.js
@@ -56,6 +56,28 @@ async function logError(interaction, error) {
   _logToDiscord(interaction.guild, { embeds: [logErrorEmbed] }, "logError");
 }
 
+async function logFallbackResolved(interaction, raw, resolvedEventId, eventName) {
+  const logEmbed = new EmbedBuilder()
+    .setTitle("Event resolved by name fallback")
+    .setDescription(
+      "Discord submitted a non-numeric `event` option (likely cached stale state). " +
+        "The bot recovered by exact-name lookup."
+    )
+    .setFields(
+      { inline: false, name: "Guild", value: `${interaction.guild.name} (${interaction.guild.id})` },
+      { inline: false, name: "Author", value: `${interaction.member.displayName} (${interaction.user.id})` },
+      { inline: false, name: "Command", value: `${interaction.commandName}` },
+      { inline: false, name: "Raw input", value: `${raw}` },
+      { inline: true, name: "Resolved id", value: `${resolvedEventId}` },
+      { inline: true, name: "Resolved name", value: `${eventName}` }
+    )
+    .setTimestamp()
+    .setColor(XPHOLDER_COLOUR)
+    .setThumbnail(interaction.client.user.avatarURL());
+
+  _logToDiscord(interaction.guild, { embeds: [logEmbed] }, "logFallbackResolved");
+}
+
 async function logRPXP(player, characterName, xp, message) {
   const logMessage = `**RPXP Awarded:** ${xp.toFixed(1)} XP to ${characterName} (${player.displayName}) for: ${message.url}`;
 
@@ -103,6 +125,7 @@ async function _logToDiscord(server, sendPayload, label) {
 module.exports = {
   logCommand,
   logError,
+  logFallbackResolved,
   logRPXP,
   logRequestXPApproval,
   logRequestXPRejection,

--- a/xpholder/utils/resolveEventId.js
+++ b/xpholder/utils/resolveEventId.js
@@ -1,0 +1,20 @@
+async function resolveEventId(guildService, raw, statusFilter) {
+  if (raw == null) return null;
+  const trimmed = String(raw).trim();
+  if (trimmed === "") return null;
+
+  // Fast path: clean integer string. Reject partial-numeric prefixes like "42 hello".
+  const parsed = parseInt(trimmed, 10);
+  if (Number.isInteger(parsed) && String(parsed) === trimmed) {
+    return { eventId: parsed, name: null, fromFallback: false };
+  }
+
+  // Fallback: exact-name lookup against the given status. Single match wins; ambiguous fails closed.
+  const matches = await guildService.searchEventsExact(trimmed, statusFilter);
+  if (matches.length === 1) {
+    return { eventId: matches[0].event_id, name: matches[0].name, fromFallback: true };
+  }
+  return null;
+}
+
+module.exports = { resolveEventId };

--- a/xpholder/utils/resolveEventId.js
+++ b/xpholder/utils/resolveEventId.js
@@ -1,4 +1,4 @@
-async function resolveEventId(guildService, raw, statusFilter) {
+async function resolveEventId(guildService, raw, statusFilter = "active") {
   if (raw == null) return null;
   const trimmed = String(raw).trim();
   if (trimmed === "") return null;

--- a/xpholder/utils/resolveEventId.test.js
+++ b/xpholder/utils/resolveEventId.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest";
+import { resolveEventId } from "./resolveEventId.js";
+
+const stubGs = (matches = []) => ({
+  searchEventsExact: vi.fn().mockResolvedValue(matches),
+});
+
+describe("resolveEventId", () => {
+  it("returns parsed id and skips lookup for a clean numeric string", async () => {
+    const gs = stubGs();
+    const result = await resolveEventId(gs, "42", "active");
+    expect(result).toEqual({ eventId: 42, name: null, fromFallback: false });
+    expect(gs.searchEventsExact).not.toHaveBeenCalled();
+  });
+
+  it("trims surrounding whitespace before parsing", async () => {
+    const gs = stubGs();
+    const result = await resolveEventId(gs, "  42  ", "active");
+    expect(result).toEqual({ eventId: 42, name: null, fromFallback: false });
+    expect(gs.searchEventsExact).not.toHaveBeenCalled();
+  });
+
+  it("rejects partial-numeric input and falls through to lookup", async () => {
+    const gs = stubGs();
+    const result = await resolveEventId(gs, "42 hello", "active");
+    expect(result).toBeNull();
+    expect(gs.searchEventsExact).toHaveBeenCalledWith("42 hello", "active");
+  });
+
+  it("returns null for empty string without calling lookup", async () => {
+    const gs = stubGs();
+    const result = await resolveEventId(gs, "", "active");
+    expect(result).toBeNull();
+    expect(gs.searchEventsExact).not.toHaveBeenCalled();
+  });
+
+  it("returns null for null/undefined input without calling lookup", async () => {
+    const gs = stubGs();
+    expect(await resolveEventId(gs, null, "active")).toBeNull();
+    expect(await resolveEventId(gs, undefined, "active")).toBeNull();
+    expect(gs.searchEventsExact).not.toHaveBeenCalled();
+  });
+
+  it("returns the matched event when fallback finds exactly one row", async () => {
+    const gs = stubGs([{ event_id: 99, name: "My Event" }]);
+    const result = await resolveEventId(gs, "My Event", "active");
+    expect(result).toEqual({ eventId: 99, name: "My Event", fromFallback: true });
+    expect(gs.searchEventsExact).toHaveBeenCalledWith("My Event", "active");
+  });
+
+  it("returns null when fallback finds multiple matches", async () => {
+    const gs = stubGs([
+      { event_id: 1, name: "Arena" },
+      { event_id: 2, name: "Arena" },
+    ]);
+    const result = await resolveEventId(gs, "Arena", "active");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when fallback finds zero matches", async () => {
+    const gs = stubGs([]);
+    const result = await resolveEventId(gs, "No Such Event", "active");
+    expect(result).toBeNull();
+  });
+
+  it("forwards statusFilter through to the lookup", async () => {
+    const gs = stubGs();
+    await resolveEventId(gs, "X", "completed");
+    expect(gs.searchEventsExact).toHaveBeenCalledWith("X", "completed");
+  });
+});

--- a/xpholder/utils/resolveEventOption.js
+++ b/xpholder/utils/resolveEventOption.js
@@ -1,0 +1,27 @@
+const { resolveEventId } = require("./resolveEventId");
+const { logFallbackResolved } = require("./logging");
+
+const ERROR_MSG =
+  "Couldn't identify that event. Try running the command again from a fresh slash command (clear any pre-filled options), then pick from the dropdown.";
+
+async function resolveEventOption(interaction, guildService, statusFilter = "active") {
+  const raw = interaction.options.getString("event");
+  const result = await resolveEventId(guildService, raw, statusFilter);
+
+  if (result == null) {
+    await interaction.editReply(ERROR_MSG);
+    return null;
+  }
+
+  if (result.fromFallback) {
+    try {
+      await logFallbackResolved(interaction, raw, result.eventId, result.name);
+    } catch (err) {
+      console.error("logFallbackResolved failed:", err);
+    }
+  }
+
+  return result.eventId;
+}
+
+module.exports = { resolveEventOption, ERROR_MSG };


### PR DESCRIPTION
There's a lot more here than it actually does. 

In production, I observed a Discord client bug where, after a user has filled multiple options on an event command in the recent past, subsequent uses submit a stale text value (the event's display name) for the `event` option instead of the autocomplete-picked id., so the command rejects even though I appeared to select correctly from the dropdown. The workaround was to submit a clean slash command with no other options, which I discovered only by trial/error.

This PR adds a defensive fallback to recover from submission cache pollution and provides a more accurate error message for the unrecoverable case.