### PR TITLE
Preserve legacy tier brackets via events.original_tier

### DIFF
--- a/dashboard/views/event-detail.ejs
+++ b/dashboard/views/event-detail.ejs
@@ -19,7 +19,13 @@
     </div>
     <div class="bg-gray-800 rounded-lg p-4 border border-gray-700">
       <p class="text-sm text-gray-400">Tier</p>
-      <p class="text-lg font-semibold"><%= event.tier %></p>
+      <p class="text-lg font-semibold">
+        <% if (event.original_tier) { %>
+          <%= event.original_tier %> <span class="text-sm text-gray-400 font-normal">(legacy)</span>
+        <% } else { %>
+          <%= event.tier %>
+        <% } %>
+      </p>
     </div>
     <div class="bg-gray-800 rounded-lg p-4 border border-gray-700">
       <p class="text-sm text-gray-400">Start Date</p>

--- a/dashboard/views/events.ejs
+++ b/dashboard/views/events.ejs
@@ -74,7 +74,13 @@
             <a href="/event/<%= event.event_id %>" class="text-indigo-400 hover:text-indigo-300"><%= event.name %></a>
           </td>
           <td class="px-4 py-3 text-sm whitespace-nowrap"><%= event.event_type %></td>
-          <td class="px-4 py-3 text-sm whitespace-nowrap"><%= event.tier %></td>
+          <td class="px-4 py-3 text-sm whitespace-nowrap">
+            <% if (event.original_tier) { %>
+              <%= event.original_tier %> <span class="text-xs text-gray-500">(legacy)</span>
+            <% } else { %>
+              <%= event.tier %>
+            <% } %>
+          </td>
           <td class="px-4 py-3 whitespace-nowrap">
             <span class="text-xs px-2 py-1 rounded-full <%= event.status === 'active' ? 'bg-green-900 text-green-300' : 'bg-blue-900 text-blue-300' %>">
               <%= event.status %>

--- a/xpholder/services/guild.js
+++ b/xpholder/services/guild.js
@@ -427,6 +427,12 @@ class guildService {
       await this.db.query(
         `ALTER TABLE ${this.schema}.event_participants ADD COLUMN IF NOT EXISTS character_name TEXT;`
       );
+      // original_tier preserves the pre-2024 CSV bracket (e.g. "3-5") for
+      // legacy events; tier itself holds the closest current bracket so
+      // grouping/filtering keeps the new vocabulary.
+      await this.db.query(
+        `ALTER TABLE ${this.schema}.events ADD COLUMN IF NOT EXISTS original_tier TEXT;`
+      );
     }
     console.log("Finished updateRegistration");
   }
@@ -518,6 +524,7 @@ class guildService {
         xp_reward INTEGER,
         gp_reward INTEGER,
         status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'completed')),
+        original_tier TEXT,
         created_at TIMESTAMP DEFAULT NOW()
       );`
     );


### PR DESCRIPTION
Pre-Aoril 2024 events used tier brackets that don't exist in the current vocabulary (3-5, 6-8, 9-12, 13-16, plus a few one-offs). The original seeding indiscriminately mapped any non-matching value to '3-4', losing the actual bracket and skewing tier-based stats.

This PR adds a nullable events.original_tier column to capture the pre-mapped value. tier itself holds the closest current bracket so grouping and filtering keep using the new vocabulary. Display logic on /events and /event/:id renders 'X (legacy)' when original_tier is set; otherwise, just the tier as before.

There is an accompanying one-time SQL backfill held locally.