### PR TITLE
Pc rename snapshot sync

### DIFF
--- a/xpholder/commands/everyone/editCharacter.js
+++ b/xpholder/commands/everyone/editCharacter.js
@@ -119,12 +119,30 @@ module.exports = {
       player_id: player.id,
       xp: character["xp"],
     };
+    const oldName = character["name"];
     await guildService.updateCharacterInfo(updatedCharacter);
+
+    // Keep event_participants snapshots in sync with the live name, so
+    // dashboard history grouping (which keys by character_name) follows
+    // the rename. No-op when the name didn't actually change.
+    if (characterName !== oldName) {
+      await guildService.renameCharacterParticipations(
+        updatedCharacter.character_id,
+        oldName,
+        characterName
+      );
+    }
+
+    // Show active event on the post-edit embed too (matches /xp).
+    const activeEvent = await guildService.getActiveEventForCharacter(
+      updatedCharacter.character_id
+    );
+
     const characterEmbed = buildCharacterEmbed(
       guildService,
       player,
       updatedCharacter,
-      characterNumber
+      activeEvent
     );
 
     await interaction.editReply({ embeds: [characterEmbed] });

--- a/xpholder/commands/mod/editOtherCharacter.js
+++ b/xpholder/commands/mod/editOtherCharacter.js
@@ -144,13 +144,30 @@ module.exports = {
       player_id: player.id,
       xp: character["xp"],
     };
+    const oldName = character["name"];
     await guildService.updateCharacterInfo(updatedCharacter);
+
+    // Keep event_participants snapshots in sync with the live name, so
+    // dashboard history grouping (which keys by character_name) follows
+    // the rename. No-op when the name didn't actually change.
+    if (characterName !== oldName) {
+      await guildService.renameCharacterParticipations(
+        updatedCharacter.character_id,
+        oldName,
+        characterName
+      );
+    }
+
+    // Show active event on the post-edit embed too (matches /xp).
+    const activeEvent = await guildService.getActiveEventForCharacter(
+      updatedCharacter.character_id
+    );
 
     const characterEmbed = buildCharacterEmbed(
       guildService,
       player,
       updatedCharacter,
-      characterNumber
+      activeEvent
     );
 
     await interaction.editReply({ embeds: [characterEmbed] });

--- a/xpholder/services/guild.integration.test.js
+++ b/xpholder/services/guild.integration.test.js
@@ -526,6 +526,44 @@ describe("events", () => {
       expect(result).toBeNull();
     });
   });
+
+  describe("renameCharacterParticipations", () => {
+    it("rewrites snapshots that match (character_id, oldName)", async () => {
+      const { gService } = ctx;
+      const eventId = await makeEvent({ name: "Quest A" });
+      await gService.addEventParticipant(eventId, "char-1", "p1", "Foo", 3, 0);
+
+      await gService.renameCharacterParticipations("char-1", "Foo", "Bar");
+
+      const participants = await gService.getEventParticipants(eventId);
+      expect(participants).toHaveLength(1);
+      expect(participants[0].character_name).toBe("Bar");
+    });
+
+    it("doesn't touch rows whose character_name doesn't match oldName", async () => {
+      const { gService } = ctx;
+      const eventA = await makeEvent({ name: "Quest A" });
+      const eventB = await makeEvent({ name: "Quest B" });
+      // Same character_id, different snapshot names — e.g. a retired-then-recreated PC
+      await gService.addEventParticipant(eventA, "char-1", "p1", "Foo", 3, 0);
+      await gService.addEventParticipant(eventB, "char-1", "p1", "Baz", 3, 0);
+
+      await gService.renameCharacterParticipations("char-1", "Foo", "Bar");
+
+      const aParticipants = await gService.getEventParticipants(eventA);
+      const bParticipants = await gService.getEventParticipants(eventB);
+      expect(aParticipants[0].character_name).toBe("Bar");
+      expect(bParticipants[0].character_name).toBe("Baz");
+    });
+
+    it("is a no-op for a character_id with zero participations", async () => {
+      const { gService } = ctx;
+      // No participants inserted; method should not throw.
+      await expect(
+        gService.renameCharacterParticipations("char-nobody", "Foo", "Bar")
+      ).resolves.toBeUndefined();
+    });
+  });
 });
 
 describe("event_participants", () => {

--- a/xpholder/services/guild.js
+++ b/xpholder/services/guild.js
@@ -594,6 +594,15 @@ class guildService {
     return res.rows[0] || null;
   }
 
+  async renameCharacterParticipations(characterId, oldName, newName) {
+    await this.db.query(
+      `UPDATE ${this.schema}.event_participants
+       SET character_name = $1
+       WHERE character_id = $2 AND character_name = $3;`,
+      [newName, characterId, oldName]
+    );
+  }
+
   async getEvents(status = null) {
     if (status) {
       const res = await this.db.query(


### PR DESCRIPTION
This "fixes" a "bug" identified by @benubu when renaming a PC... it completely borks event history (and active event).

This is less a bug than a known limitation, yet again... of not having unique IDs for PCs. This is yet another workaround for that problem, doing two things:
- correcting the arguments in the current event lookup function
- ensuring that a PC's history follows them when their name is changed

This will cause some chaos if a player names a future character the same name as a past character. Since this is explicitly not allowed by the server, I don't anticipate it being a problem.