### PR TITLE
Fix PCs in Events undercount on dashboard home page

### DIFF
--- a/dashboard/db.js
+++ b/dashboard/db.js
@@ -268,6 +268,21 @@ function levelFromXp(xp, thresholds) {
   return 1;
 }
 
+function bucketCharactersByLevel(charsWithXp, brackets, thresholds) {
+  const byBracket = {};
+  for (const b of brackets) byBracket[b.label] = new Set();
+  for (const c of charsWithXp) {
+    const level = levelFromXp(c.xp, thresholds);
+    for (const b of brackets) {
+      if (level >= b.min && level <= b.max) {
+        byBracket[b.label].add(c.character_id);
+        break;
+      }
+    }
+  }
+  return byBracket;
+}
+
 async function getActivePcStats(guildId) {
   validateGuildId(guildId);
   const schema = `guild${guildId}`;
@@ -306,41 +321,29 @@ async function getActivePcStats(guildId) {
     }).sort((a, b) => a.min - b.min);
   }
 
-  // Count all characters per bracket
-  const charsByBracket = {};
-  for (const b of brackets) charsByBracket[b.label] = new Set();
+  const charsByBracket = bucketCharactersByLevel(charsRes.rows, brackets, thresholds);
 
-  for (const c of charsRes.rows) {
-    const level = levelFromXp(c.xp, thresholds);
-    for (const b of brackets) {
-      if (level >= b.min && level <= b.max) {
-        charsByBracket[b.label].add(c.character_id);
-        break;
-      }
-    }
-  }
-
-  // Get PCs in active events, grouped by event tier (only active players)
+  // Get distinct PCs in active events with their current XP, then bucket by PC
+  // level (not event tier) so participants in Open / mismatched-tier events
+  // still count under their character's bracket.
   const activeQuery = hasPlayers
-    ? `SELECT e.tier, COUNT(DISTINCT ep.character_id) as in_events
+    ? `SELECT DISTINCT c.character_id, c.xp
        FROM ${schema}.event_participants ep
        JOIN ${schema}.events e ON ep.event_id = e.event_id
        JOIN ${schema}.characters c ON ep.character_id = c.character_id
        JOIN ${schema}.players p ON c.player_id = p.player_id
        WHERE e.status = 'active'
+         AND (ep.removal_reason IS NULL OR ep.removal_reason = 'death')
          AND p.is_member = TRUE
-         AND (p.inactive_days IS NULL OR p.inactive_days < 90)
-       GROUP BY e.tier;`
-    : `SELECT e.tier, COUNT(DISTINCT ep.character_id) as in_events
+         AND (p.inactive_days IS NULL OR p.inactive_days < 90);`
+    : `SELECT DISTINCT c.character_id, c.xp
        FROM ${schema}.event_participants ep
        JOIN ${schema}.events e ON ep.event_id = e.event_id
+       JOIN ${schema}.characters c ON ep.character_id = c.character_id
        WHERE e.status = 'active'
-       GROUP BY e.tier;`;
+         AND (ep.removal_reason IS NULL OR ep.removal_reason = 'death');`;
   const activeRes = await pool.query(activeQuery);
-  const inEventsByTier = {};
-  for (const row of activeRes.rows) {
-    inEventsByTier[row.tier] = parseInt(row.in_events);
-  }
+  const inEventsByBracket = bucketCharactersByLevel(activeRes.rows, brackets, thresholds);
 
   // Days since last event started per tier
   const lastEventRes = await pool.query(
@@ -357,7 +360,7 @@ async function getActivePcStats(guildId) {
   // Build result
   const rows = brackets.map((b) => {
     const activePcs = charsByBracket[b.label].size;
-    const inEvents = inEventsByTier[b.label] || 0;
+    const inEvents = inEventsByBracket[b.label].size;
     const pctInEvents = activePcs > 0 ? ((inEvents / activePcs) * 100).toFixed(1) : "0.0";
     const daysSince = lastEventByTier[b.label] != null ? lastEventByTier[b.label] : null;
     return {
@@ -701,4 +704,4 @@ async function getPlayerHistoryByName(guildId, playerId) {
   return byName;
 }
 
-module.exports = { pool, getRegisteredGuilds, getGuildConfig, getEventStats, getEvents, getEvent, getDroppedParticipants, hasEventsTable, getActivePcStats, getDmStats, hasPlayersTable, getPlayerStats, loadLevelThresholds, levelFromXp, searchPlayersAndCharacters, getPlayerDetail, getPlayerHistoryByName };
+module.exports = { pool, getRegisteredGuilds, getGuildConfig, getEventStats, getEvents, getEvent, getDroppedParticipants, hasEventsTable, getActivePcStats, getDmStats, hasPlayersTable, getPlayerStats, loadLevelThresholds, levelFromXp, bucketCharactersByLevel, searchPlayersAndCharacters, getPlayerDetail, getPlayerHistoryByName };

--- a/dashboard/db.test.js
+++ b/dashboard/db.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { levelFromXp } from "./db.js";
+import { levelFromXp, bucketCharactersByLevel } from "./db.js";
 
 // A 5-level fixture: level 1 = [0, 100), level 2 = [100, 300),
 // level 3 = [300, 600), level 4 = [600, 1000), level 5 = [1000, ...).
@@ -35,5 +35,61 @@ describe("levelFromXp", () => {
     // 21 thresholds → level 21 would be reachable without the cap.
     const longThresholds = Array.from({ length: 21 }, (_, i) => i * 100);
     expect(levelFromXp(2_000_000, longThresholds)).toBe(20);
+  });
+});
+
+describe("bucketCharactersByLevel", () => {
+  // Brackets covering levels 1-2, 3-4, 5+
+  const BRACKETS = [
+    { label: "1-2", min: 1, max: 2 },
+    { label: "3-4", min: 3, max: 4 },
+    { label: "5-5", min: 5, max: 5 },
+  ];
+
+  it("assigns each character to the bracket containing its level", () => {
+    const result = bucketCharactersByLevel(
+      [
+        { character_id: "a", xp: 0 },     // level 1
+        { character_id: "b", xp: 450 },   // level 3
+        { character_id: "c", xp: 1000 },  // level 5
+      ],
+      BRACKETS,
+      FIXTURE_THRESHOLDS
+    );
+
+    expect([...result["1-2"]]).toEqual(["a"]);
+    expect([...result["3-4"]]).toEqual(["b"]);
+    expect([...result["5-5"]]).toEqual(["c"]);
+  });
+
+  it("deduplicates the same character_id appearing multiple times", () => {
+    const result = bucketCharactersByLevel(
+      [
+        { character_id: "a", xp: 0 },
+        { character_id: "a", xp: 0 },
+        { character_id: "a", xp: 0 },
+      ],
+      BRACKETS,
+      FIXTURE_THRESHOLDS
+    );
+
+    expect(result["1-2"].size).toBe(1);
+  });
+
+  it("drops characters whose level lies outside every bracket", () => {
+    const narrowBrackets = [{ label: "3-4", min: 3, max: 4 }];
+
+    const result = bucketCharactersByLevel(
+      [
+        { character_id: "below", xp: 0 },     // level 1
+        { character_id: "inside", xp: 450 },  // level 3
+        { character_id: "above", xp: 1000 },  // level 5
+      ],
+      narrowBrackets,
+      FIXTURE_THRESHOLDS
+    );
+
+    expect([...result["3-4"]]).toEqual(["inside"]);
+    expect(Object.keys(result)).toEqual(["3-4"]);
   });
 });


### PR DESCRIPTION
Bucket active-event participants by character level instead of event tier so PCs in Open or off-tier events are still counted. Exclude participants with removal_reason='dropped' to match the per-event participant_count column on /events.

Extracts the existing bracket-bucketing loop as bucketCharactersByLevel, covered by unit tests.