### PR TITLE
Allow mods to add PC via event_edit.

### DIFF
--- a/main.js
+++ b/main.js
@@ -44,6 +44,7 @@ const {
   handleRequestXpCommandButton,
 } = require("./xpholder/commands/everyone/requestXp.js");
 const {
+  handleAddPcOpenButton,
   handleAddPcUserSelect,
   handleAddPcCharacterSelect,
   handleAddPcDoneButton,
@@ -271,6 +272,8 @@ client.on("interactionCreate", async (interaction) => {
       handleXpCommandButton(gService, interaction);
     } else if (interaction.customId.startsWith("event_add_pc_done:")) {
       handleAddPcDoneButton(gService, interaction);
+    } else if (interaction.customId.startsWith("event_add_pc_open:")) {
+      handleAddPcOpenButton(gService, interaction);
     } else if (interaction.customId.startsWith("event_edit_text:")) {
       handleEditTextButton(gService, interaction);
     }

--- a/xpholder/commands/mod/eventAddPc.js
+++ b/xpholder/commands/mod/eventAddPc.js
@@ -7,6 +7,38 @@ const {
 } = require("../../utils/eventAddPcHelpers");
 const { logEventParticipantAdded } = require("../../utils/logging");
 
+// Opens the add-PC picker from the /event_edit message. Unlike the
+// /event_add_pc command, this entry point works on completed events too — the
+// editor is the only way to reach a non-active event here.
+async function handleAddPcOpenButton(guildService, interaction) {
+  const parsed = parseAddPcCustomId(interaction.customId);
+  if (!parsed) return;
+  const eventId = parsed.eventId;
+
+  const event = await guildService.getEvent(eventId);
+  if (!event) {
+    try {
+      await interaction.update({ content: "This event no longer exists.", embeds: [], components: [] });
+    } catch (err) {
+      console.error("interaction.update failed:", err);
+    }
+    return;
+  }
+
+  const active = await guildService.getActiveEventParticipants(eventId);
+  const dropped = await guildService.getDroppedEventParticipants(eventId);
+
+  try {
+    await interaction.update(buildAddPcMessage(event, active, dropped, null, []));
+  } catch (err) {
+    console.error("interaction.update failed:", err);
+    await interaction.followUp({
+      content: "The add-PC editor could not be opened. Re-run /event_edit to continue.",
+      ephemeral: true,
+    });
+  }
+}
+
 async function handleAddPcUserSelect(guildService, interaction) {
   const parsed = parseAddPcCustomId(interaction.customId);
   if (!parsed) return;
@@ -22,9 +54,9 @@ async function handleAddPcUserSelect(guildService, interaction) {
   }
 
   const event = await guildService.getEvent(eventId);
-  if (!event || event.status !== "active") {
+  if (!event) {
     try {
-      await interaction.update({ content: "This event is no longer active.", embeds: [], components: [] });
+      await interaction.update({ content: "This event no longer exists.", embeds: [], components: [] });
     } catch (err) {
       console.error("interaction.update failed:", err);
     }
@@ -68,9 +100,9 @@ async function handleAddPcCharacterSelect(guildService, interaction) {
   const characterId = `${playerId}-${characterIndex}`;
 
   const event = await guildService.getEvent(eventId);
-  if (!event || event.status !== "active") {
+  if (!event) {
     try {
-      await interaction.update({ content: "This event is no longer active.", embeds: [], components: [] });
+      await interaction.update({ content: "This event no longer exists.", embeds: [], components: [] });
     } catch (err) {
       console.error("interaction.update failed:", err);
     }
@@ -194,6 +226,7 @@ module.exports = {
       events.map((e) => ({ name: e.name, value: `${e.event_id}` }))
     );
   },
+  handleAddPcOpenButton,
   handleAddPcUserSelect,
   handleAddPcCharacterSelect,
   handleAddPcDoneButton,

--- a/xpholder/utils/eventAddPcHelpers.js
+++ b/xpholder/utils/eventAddPcHelpers.js
@@ -11,15 +11,15 @@ const { formatParticipantName } = require("./participantRender");
 
 function parseAddPcCustomId(customId) {
   if (typeof customId !== "string") return null;
-  const match = /^event_add_pc_(user|char|done):(\d+)(?::(\d+))?(?::n\d+)?$/.exec(customId);
+  const match = /^event_add_pc_(user|char|done|open):(\d+)(?::(\d+))?(?::n\d+)?$/.exec(customId);
   if (!match) return null;
   const kind = match[1];
   const eventId = parseInt(match[2], 10);
   const playerId = match[3] ?? null;
 
-  // char REQUIRES a playerId; user/done MUST NOT have one
+  // char REQUIRES a playerId; user/done/open MUST NOT have one
   if (kind === "char" && playerId == null) return null;
-  if ((kind === "user" || kind === "done") && playerId != null) return null;
+  if ((kind === "user" || kind === "done" || kind === "open") && playerId != null) return null;
 
   return { kind, eventId, playerId };
 }

--- a/xpholder/utils/eventAddPcHelpers.test.js
+++ b/xpholder/utils/eventAddPcHelpers.test.js
@@ -10,6 +10,7 @@ describe("parseAddPcCustomId", () => {
     ["event_add_pc_user:42:n3", { kind: "user", eventId: 42, playerId: null }],
     ["event_add_pc_char:42:1234567890", { kind: "char", eventId: 42, playerId: "1234567890" }],
     ["event_add_pc_done:42", { kind: "done", eventId: 42, playerId: null }],
+    ["event_add_pc_open:42", { kind: "open", eventId: 42, playerId: null }],
   ])("parses %s", (customId, expected) => {
     expect(parseAddPcCustomId(customId)).toEqual(expected);
   });
@@ -17,6 +18,7 @@ describe("parseAddPcCustomId", () => {
   it.each([
     "event_add_pc_user:42:extra",     // user must NOT have a playerId segment
     "event_add_pc_done:42:extra",     // done must NOT have a playerId segment
+    "event_add_pc_open:42:extra",     // open must NOT have a playerId segment
     "event_add_pc_char:42",           // char REQUIRES a playerId segment
     "event_add_pc_other:42",          // unknown kind
     "event_add_pc_user:abc",          // non-numeric eventId

--- a/xpholder/utils/eventEditHelpers.js
+++ b/xpholder/utils/eventEditHelpers.js
@@ -167,7 +167,11 @@ function buildEventEditMessage(event, dms) {
     new ButtonBuilder()
       .setCustomId(`event_edit_text:${event.event_id}`)
       .setLabel("Edit Name, Dates & Rewards")
-      .setStyle(ButtonStyle.Primary)
+      .setStyle(ButtonStyle.Primary),
+    new ButtonBuilder()
+      .setCustomId(`event_add_pc_open:${event.event_id}`)
+      .setLabel("Add PC")
+      .setStyle(ButtonStyle.Secondary)
   );
 
   return { embeds: [embed], components: [typeRow, tierRow, dmRow, channelRow, buttonRow] };


### PR DESCRIPTION
This adds the "Add PC" interaction to the `event_edit` command, which in turn allows an admin to add a user to a completed event (not previously possible)

<img width="668" height="584" alt="_general___ER_Dev_-_Discord" src="https://github.com/user-attachments/assets/25eb51da-9bb5-4b84-9015-2ea698054787" />


<img width="774" height="481" alt="_general___ER_Dev_-_Discord" src="https://github.com/user-attachments/assets/4aa61492-a486-4c6a-9f9b-96cff63d2b0a" />
